### PR TITLE
Read "updated" DateTime in en_US language

### DIFF
--- a/manganelo/api/mangainfo.py
+++ b/manganelo/api/mangainfo.py
@@ -1,6 +1,7 @@
 import dataclasses
 import typing
 import ast
+import locale
 
 import functools as ft
 
@@ -171,10 +172,12 @@ class MangaInfo(APIBase):
 
         updated, views, *_ = rows
 
-        # Remove AM and PM
-        updated = updated[0:-3]
+        # Standardize locale to match foreign language
+        curr_local = locale.getlocale()[0]
+        locale.setlocale(locale.LC_ALL, "en_US")
+        updated = datetime.strptime(updated, "%b %d,%Y - %I:%M %p")
+        locale.setlocale(locale.LC_ALL, curr_local)
 
-        updated = datetime.strptime(updated, "%b %d,%Y - %H:%M")
         views = int(views.replace(",", ""))
 
         return {"updated": updated, "views": views}

--- a/manganelo/api/mangainfo.py
+++ b/manganelo/api/mangainfo.py
@@ -175,7 +175,7 @@ class MangaInfo(APIBase):
         # Standardize locale to match foreign language
         curr_local = locale.getlocale()[0]
         locale.setlocale(locale.LC_ALL, "en_US")
-        updated = datetime.strptime(updated, "%b %d,%Y - %I:%M %p")
+        updated = datetime.strptime(updated, "%b %d,%Y - %H:%M %p")
         locale.setlocale(locale.LC_ALL, curr_local)
 
         views = int(views.replace(",", ""))


### PR DESCRIPTION
As everyone can have a different locale, I couldn't parse the date as "Mar" is in my language "Bře". This sets the locale to en_US before converting time, ensuring the date can be processed. Later on, the locale is set back to the previous value.