### PR TITLE
Fixing get/setlocale

### DIFF
--- a/manganelo/api/mangainfo.py
+++ b/manganelo/api/mangainfo.py
@@ -173,10 +173,9 @@ class MangaInfo(APIBase):
         updated, views, *_ = rows
 
         # Standardize locale to match foreign language
-        curr_local = locale.getlocale()[0]
-        locale.setlocale(locale.LC_ALL, "en_US")
+        locale.setlocale(locale.LC_ALL, "en_US.UTF8")
         updated = datetime.strptime(updated, "%b %d,%Y - %H:%M %p")
-        locale.setlocale(locale.LC_ALL, curr_local)
+        locale.setlocale(locale.LC_ALL, '')
 
         views = int(views.replace(",", ""))
 


### PR DESCRIPTION
It was crashing on my Ubuntu machine.  
As described in the Python docs, we have to provide both the language code and encoding.

Also it some cases getlocale() might return `None`, but setlocale() won't accept that. 
Again, the docs says that we can use an empty string to revert to the user’s default setting.

https://docs.python.org/3/library/locale.html#locale.setlocale

Tested on Ubuntu 20.04 with python 3.8.9 and Windows 10 with python 3.8.1.