### PR TITLE
Fix problems with authors and genres parsing

### DIFF
--- a/manganelo/models/searchresult.py
+++ b/manganelo/models/searchresult.py
@@ -32,9 +32,12 @@ class SearchResult:
 
     @staticmethod
     def _parse_authors(soup) -> list[str]:
-        txt = soup.find("span", class_="text-nowrap item-author").text
-
-        return utils.split_at(txt, ",")
+        authors = soup.find("span", class_="text-nowrap item-author")
+        if authors:
+          txt = authors.text
+          return utils.split_at(txt, ",")
+        else:
+          return []
 
     @staticmethod
     def _parse_views(soup) -> int:

--- a/manganelo/models/storypage.py
+++ b/manganelo/models/storypage.py
@@ -32,15 +32,14 @@ class StoryPage:
 
     @staticmethod
     def _parse_authors(soup):
-        values = soup.find("table", class_="variations-tableInfo").find_all("td", class_="table-value")
-        author = values[1]
+        authors_row = soup.find("i", class_="info-author").findNext("td", class_="table-value")
 
-        return [e.strip() for e in author.text.split(",")]
+        return [e.strip() for e in authors_row.text.split(" - ")]
 
     @staticmethod
     def _parse_genres(soup):
-        values = soup.find("table", class_="variations-tableInfo").find_all("td", class_="table-value")
-        genres = values[3].find_all("a", class_="a-h")
+        genres_row = soup.find("i", class_="info-genres").findNext("td", class_="table-value")
+        genres = genres_row.find_all("a", class_="a-h")
 
         return [e.text.strip() for e in genres]
 


### PR DESCRIPTION
Fixes searching for mangas with no authors in issue #17 

And another problem: [Attack On Titan Anthology](https://readmanganato.com/manga-fv982830) has no alternative name raw in table `variations-tableInfo` so we go out of range looking for genres

```
Python 3.10.5 (main, Jun  6 2022, 18:49:26) [GCC 12.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import manganelo
>>> manganelo.storypage.get_story_page('https://readmanganato.com/manga-fv982830')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/nvme/documents/projects/manganelo-test/venv/lib/python3.10/site-packages/manganelo/storypage.py", line 16, in get_story_page
    return StoryPage(url, soup)
  File "/mnt/nvme/documents/projects/manganelo-test/venv/lib/python3.10/site-packages/manganelo/models/storypage.py", line 19, in __init__
    self.genres: list[str] = self._parse_genres(soup)
  File "/mnt/nvme/documents/projects/manganelo-test/venv/lib/python3.10/site-packages/manganelo/models/storypage.py", line 43, in _parse_genres
    genres = values[3].find_all("a", class_="a-h")
IndexError: list index out of range
```
Changed authors and genres parsing to look up its rows by name